### PR TITLE
Add compliance with RFC version 4 spec

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -11,6 +11,7 @@ func GenerateUUID() string {
 	if _, err := rand.Read(buf); err != nil {
 		panic(fmt.Errorf("failed to read random bytes: %v", err))
 	}
+	buf[6] = (buf[6] & 0x0F) | 0x40 // https://tools.ietf.org/html/rfc4122#section-4.1.3
 
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
 		buf[0:4],

--- a/uuid.go
+++ b/uuid.go
@@ -11,7 +11,8 @@ func GenerateUUID() string {
 	if _, err := rand.Read(buf); err != nil {
 		panic(fmt.Errorf("failed to read random bytes: %v", err))
 	}
-	buf[6] = (buf[6] & 0x0F) | 0x40 // https://tools.ietf.org/html/rfc4122#section-4.1.3
+	buf[6] = (buf[6] & 0x0F) | 0x40 // Version: https://tools.ietf.org/html/rfc4122#section-4.1.3
+	buf[8] = (buf[8] & 0x3F) | 0x80 // Variant: https://tools.ietf.org/html/rfc4122#section-4.1.1
 
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
 		buf[0:4],

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -14,7 +14,7 @@ func TestGenerateUUID(t *testing.T) {
 		}
 
 		matched, err := regexp.MatchString(
-			"[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}", id)
+			"[\\da-f]{8}-[\\da-f]{4}-4[\\da-f]{3}-[\\da-f]{4}-[\\da-f]{12}", id)
 		if !matched || err != nil {
 			t.Fatalf("expected match %s %v %s", id, matched, err)
 		}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -14,7 +14,7 @@ func TestGenerateUUID(t *testing.T) {
 		}
 
 		matched, err := regexp.MatchString(
-			"[\\da-f]{8}-[\\da-f]{4}-4[\\da-f]{3}-[\\da-f]{4}-[\\da-f]{12}", id)
+			"[\\da-f]{8}-[\\da-f]{4}-4[\\da-f]{3}-[89ab][\\da-f]{3}-[\\da-f]{12}", id)
 		if !matched || err != nil {
 			t.Fatalf("expected match %s %v %s", id, matched, err)
 		}


### PR DESCRIPTION
The version 4 spec requires a 4 in the 13th position and a variant that results in an 8,9,a or b int he 17th position. 

Reference:
https://tools.ietf.org/html/rfc4122#section-4.1.3
https://tools.ietf.org/html/rfc4122#section-4.1.1
https://en.wikipedia.org/wiki/Universally_unique_identifier

I added tests for both of these and adjusted the code accordingly.
